### PR TITLE
[dv_hmac] little more support on hmac_tx_empty

### DIFF
--- a/hw/ip/hmac/dv/env/hmac_scoreboard.sv
+++ b/hw/ip/hmac/dv/env/hmac_scoreboard.sv
@@ -273,12 +273,7 @@ class hmac_scoreboard extends cip_base_scoreboard #(.CFG_T (hmac_env_cfg),
       // when hmac_wr_cnt and hmac_rd_cnt update at the same time, wait 1ps to guarantee
       // get both update
       #1ps;
-      //if ((hmac_wr_cnt - hmac_rd_cnt) == HMAC_MSG_FIFO_DEPTH) begin
-      //  void'(ral.intr_state.fifo_full.predict(.value(1)));
-      //  `uvm_info(`gfn, "predict interrupt fifo full is set", UVM_HIGH)
-      //  fifo_full = 1;
-      //end else
-      if (hmac_wr_cnt == hmac_rd_cnt) begin
+      if ((hmac_wr_cnt == hmac_rd_cnt) && hmac_start) begin
         // FIFO write/read pointers are same --> FIFO Empty event occurs
         // Remember the initial status is Empty but the event won't occur
         void'(ral.intr_state.fifo_empty.predict(.value(1)));
@@ -340,9 +335,6 @@ class hmac_scoreboard extends cip_base_scoreboard #(.CFG_T (hmac_env_cfg),
               #1ps; // delay 1 ps to make sure did not sample right at negedge clk
               cfg.clk_rst_vif.wait_n_clks(1);
               hmac_rd_cnt++;
-              if (hmac_wr_cnt == hmac_rd_cnt) begin
-                fifo_empty = 1;
-              end
               `uvm_info(`gfn, $sformatf("increase rd cnt %0d", hmac_rd_cnt), UVM_HIGH)
               if (hmac_rd_cnt % HMAC_MSG_FIFO_DEPTH == 0) begin
                 cfg.clk_rst_vif.wait_n_clks(HMAC_MSG_PROCESS_CYCLES);

--- a/hw/ip/hmac/dv/env/seq_lib/hmac_sanity_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_sanity_vseq.sv
@@ -78,6 +78,7 @@ class hmac_sanity_vseq extends hmac_base_vseq;
       if (i != 1 && $urandom_range(0, 1)) rd_digest();
 
       if (sha_en || $urandom_range(0, 1)) begin
+        bit [TL_DW-1:0] intr_state_val;
         // start stream in msg
         trigger_hash();
 
@@ -111,11 +112,11 @@ class hmac_sanity_vseq extends hmac_base_vseq;
         // wait for interrupt to assert, check status and clear it
         if (intr_hmac_done_en) begin
           wait(cfg.intr_vif.pins[HmacDone] === 1'b1);
-          check_interrupts(.interrupts((1 << HmacDone)), .check_set(1'b1));
         end else begin
           csr_spinwait(.ptr(ral.intr_state.hmac_done), .exp_data(1'b1));
-          csr_wr(.csr(ral.intr_state), .value(1 << HmacDone));
         end
+        csr_rd(.ptr(ral.intr_state), .value(intr_state_val));
+        csr_wr(.csr(ral.intr_state), .value(intr_state_val));
       end
 
 


### PR DESCRIPTION
This assumes tx_empty will trigger only during reg_hash_start and
reg_hash_process

Signed-off-by: Cindy Chen <chencindy@google.com>