### PR TITLE
[hmac/dv] fix merged conflict

### DIFF
--- a/hw/ip/hmac/data/hmac.hjson
+++ b/hw/ip/hmac/data/hmac.hjson
@@ -9,8 +9,8 @@
     { name: "hmac_done",
       desc: "HMAC-256 completes a message with key"
     }
-    { name: "fifo_full",
-      desc: "Message FIFO full condition"
+    { name: "fifo_empty",
+      desc: "Message FIFO empty condition"
     }
     { name: "hmac_err",
       desc: "HMAC error occurred. ERR_CODE register shows which error occurred"

--- a/hw/ip/hmac/dv/env/hmac_env_pkg.sv
+++ b/hw/ip/hmac/dv/env/hmac_env_pkg.sv
@@ -38,7 +38,7 @@ package hmac_env_pkg;
 
   typedef enum {
     HmacDone,
-    HmacMsgFifoFull,
+    HmacMsgFifoEmpty,
     HmacErr
   } hmac_intr_e;
 

--- a/hw/ip/hmac/dv/env/hmac_scoreboard.sv
+++ b/hw/ip/hmac/dv/env/hmac_scoreboard.sv
@@ -8,7 +8,7 @@ class hmac_scoreboard extends cip_base_scoreboard #(.CFG_T (hmac_env_cfg),
   `uvm_component_utils(hmac_scoreboard)
   `uvm_component_new
 
-  bit             sha_en, fifo_full;
+  bit             sha_en, fifo_full, fifo_empty;
   bit [7:0]       msg_q[$];
   bit             hmac_start, hmac_process;
   int             hmac_wr_cnt, hmac_rd_cnt;
@@ -22,7 +22,7 @@ class hmac_scoreboard extends cip_base_scoreboard #(.CFG_T (hmac_env_cfg),
   task run_phase(uvm_phase phase);
     super.run_phase(phase);
     fork
-      hmac_process_fifo_full();
+      hmac_process_fifo_status();
       hmac_process_fifo_wr();
       hmac_process_fifo_rd();
     join_none
@@ -95,6 +95,9 @@ class hmac_scoreboard extends cip_base_scoreboard #(.CFG_T (hmac_env_cfg),
             void'(ral.intr_state.predict(.value(intr_state_exp), .kind(UVM_PREDICT_DIRECT)));
             intr_test = item.a_data;
           end
+          "intr_state": begin
+            if (item.a_data[HmacMsgFifoEmpty]) fifo_empty = 0;
+          end
           "cfg": begin
             if (hmac_start) return; // won't update configs if hash start
             if (cfg.en_cov) cov.cfg_cg.sample(item.a_data);
@@ -141,6 +144,11 @@ class hmac_scoreboard extends cip_base_scoreboard #(.CFG_T (hmac_env_cfg),
                                              (hmac_fifo_full  << HmacStaMsgFifoFull) |
                                              (hmac_fifo_depth << HmacStaMsgFifoDepth);
           void'(ral.status.predict(.value(hmac_status_data), .kind(UVM_PREDICT_READ)));
+        end else if (csr_name == "intr_state") begin
+          if (fifo_empty && ral.intr_state.fifo_empty.get_mirrored_value() != 1) begin
+            void'(ral.intr_state.fifo_empty.predict(.value(1), .kind(UVM_PREDICT_READ)));
+            `uvm_info(`gfn, "predict again", UVM_HIGH)
+          end
         end
       return;
     end
@@ -223,6 +231,7 @@ class hmac_scoreboard extends cip_base_scoreboard #(.CFG_T (hmac_env_cfg),
     hmac_rd_cnt = 0;
     intr_test   = 0;
     key         = '{default:0};
+    fifo_empty  = 0;
   endfunction
 
   // clear variables after expected digest is calculated
@@ -265,15 +274,19 @@ class hmac_scoreboard extends cip_base_scoreboard #(.CFG_T (hmac_env_cfg),
     join
   endtask
 
-  virtual task hmac_process_fifo_full();
+  virtual task hmac_process_fifo_status();
     forever @(hmac_wr_cnt, hmac_rd_cnt) begin
       // when hmac_wr_cnt and hmac_rd_cnt update at the same time, wait 1ps to guarantee
       // get both update
       #1ps;
-      if ((hmac_wr_cnt - hmac_rd_cnt) == HMAC_MSG_FIFO_DEPTH) begin
-        void'(ral.intr_state.fifo_full.predict(.value(1)));
-        `uvm_info(`gfn, "predict interrupt fifo full is set", UVM_HIGH)
-        fifo_full = 1;
+      if ((hmac_wr_cnt == hmac_rd_cnt) && (hmac_wr_cnt != 0)) begin
+        // after the rd wr pointers are equal, wait one clk cycle for the fifo_empty register
+        // update, wait another clk cycle for the register value to reflect
+        if (!fifo_empty) begin
+          cfg.clk_rst_vif.wait_clks(2);
+          `uvm_info(`gfn, "predict interrupt fifo empty is set", UVM_HIGH)
+          fifo_empty = 1;
+        end
       end
     end
   endtask
@@ -347,7 +360,7 @@ class hmac_scoreboard extends cip_base_scoreboard #(.CFG_T (hmac_env_cfg),
 
   function void check_phase(uvm_phase phase);
     super.check_phase(phase);
-    `DV_CHECK_EQ(cfg.intr_vif.pins[HmacMsgFifoFull], 1'b0)
+    `DV_CHECK_EQ(cfg.intr_vif.pins[HmacMsgFifoEmpty], 1'b0)
     `DV_CHECK_EQ(cfg.intr_vif.pins[HmacDone], 1'b0)
     `DV_CHECK_EQ(cfg.intr_vif.pins[HmacErr], 1'b0)
   endfunction

--- a/hw/ip/hmac/dv/env/seq_lib/hmac_sanity_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_sanity_vseq.sv
@@ -14,7 +14,7 @@ class hmac_sanity_vseq extends hmac_base_vseq;
   rand bit        sha_en;
   rand bit        endian_swap;
   rand bit        digest_swap;
-  rand bit        intr_fifo_full_en;
+  rand bit        intr_fifo_empty_en;
   rand bit        intr_hmac_done_en;
   rand bit        intr_hmac_err_en;
   rand bit [31:0] key[8];
@@ -42,7 +42,7 @@ class hmac_sanity_vseq extends hmac_base_vseq;
   }
 
   constraint intr_enable_c {
-    intr_fifo_full_en dist {1'b1 := 8, 1'b0 := 2};
+    intr_fifo_empty_en dist {1'b1 := 8, 1'b0 := 2};
     intr_hmac_done_en dist {1'b1 := 8, 1'b0 := 2};
     intr_hmac_err_en  dist {1'b1 := 8, 1'b0 := 2};
   }
@@ -59,12 +59,12 @@ class hmac_sanity_vseq extends hmac_base_vseq;
       `DV_CHECK_RANDOMIZE_FATAL(this)
       `uvm_info(`gfn, $sformatf("starting seq %0d/%0d, message size %0d, hmac=%0d, sha=%0d",
                                 i, num_trans, msg.size(), hmac_en, sha_en), UVM_LOW)
-      `uvm_info(`gfn, $sformatf("intr_fifo_full/hmac_done/hmac_err_en=%b, endian/digest_swap=%b",
-                                {intr_fifo_full_en, intr_hmac_done_en, intr_hmac_err_en},
+      `uvm_info(`gfn, $sformatf("intr_fifo_empty/hmac_done/hmac_err_en=%b, endian/digest_swap=%b",
+                                {intr_fifo_empty_en, intr_hmac_done_en, intr_hmac_err_en},
                                 {endian_swap, digest_swap}), UVM_HIGH)
       // initialize hmac configs
       hmac_init(.sha_en(sha_en), .hmac_en(hmac_en), .endian_swap(endian_swap),
-                .digest_swap(digest_swap), .intr_fifo_full_en(intr_fifo_full_en),
+                .digest_swap(digest_swap), .intr_fifo_empty_en(intr_fifo_empty_en),
                 .intr_hmac_done_en(intr_hmac_done_en), .intr_hmac_err_en(intr_hmac_err_en));
 
       // can randomly read previous digest
@@ -77,6 +77,7 @@ class hmac_sanity_vseq extends hmac_base_vseq;
       if (i != 1 && $urandom_range(0, 1)) rd_digest();
 
       if (sha_en || $urandom_range(0, 1)) begin
+        bit [TL_DW-1:0] intr_state_val;
         // start stream in msg
         if (do_hash_start) trigger_hash();
 
@@ -101,22 +102,21 @@ class hmac_sanity_vseq extends hmac_base_vseq;
         // msg stream in finished, start hash
         if (do_hash_start) trigger_process();
 
-        // fifo_full intr can be triggered at the latest two cycle after process
-        // example: current fifo_depth=(14 words + 2 bytes), then wr last 4 bytes, design will
-        // process the 15th word then trigger intr_fifo_full
-        cfg.clk_rst_vif.wait_clks(2);
-        clear_intr_fifo_full();
+        // TODO: temp solution as after hmac_process, scb hmac_empty has one cycle mismatch with
+        // RTL
+        if (hmac_en) cfg.clk_rst_vif.wait_clks(HMAC_KEY_PROCESS_CYCLES);
+        else cfg.clk_rst_vif.wait_clks(HMAC_MSG_PROCESS_CYCLES);
 
         if (do_hash_start) begin
           // wait for interrupt to assert, check status and clear it
           if (intr_hmac_done_en) begin
             wait(cfg.intr_vif.pins[HmacDone] === 1'b1);
-            check_interrupts(.interrupts((1 << HmacDone)), .check_set(1'b1));
           end else begin
             csr_spinwait(.ptr(ral.intr_state.hmac_done), .exp_data(1'b1));
-            csr_wr(.csr(ral.intr_state), .value(1 << HmacDone));
           end
         end
+        csr_rd(.ptr(ral.intr_state), .value(intr_state_val));
+        csr_wr(.csr(ral.intr_state), .value(intr_state_val));
       end
 
       // if disable sha, digest should be cleared

--- a/hw/ip/hmac/dv/env/seq_lib/hmac_test_vectors_sha_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_test_vectors_sha_vseq.sv
@@ -49,7 +49,7 @@ class hmac_test_vectors_sha_vseq extends hmac_base_vseq;
         // example: current fifo_depth=(14 words + 2 bytes), then wr last 4 bytes, design will
         // process the 15th word then trigger intr_fifo_full
         cfg.clk_rst_vif.wait_clks(2);
-        clear_intr_fifo_full();
+        //clear_intr_fifo_full();
 
         wait(cfg.intr_vif.pins[HmacDone] === 1'b1);
         check_interrupts(.interrupts((1 << HmacDone)), .check_set(1'b1));

--- a/hw/ip/hmac/dv/tb/tb.sv
+++ b/hw/ip/hmac/dv/tb/tb.sv
@@ -20,7 +20,7 @@ module tb;
   wire [NUM_MAX_INTERRUPTS-1:0]  interrupts;
 
   wire intr_hmac_done;
-  wire intr_fifo_full;
+  wire intr_fifo_empty;
   wire intr_hmac_err;
 
   // parameters
@@ -42,16 +42,16 @@ module tb;
     .tl_o               ( tl_if.d2h      ),
 
     .intr_hmac_done_o   ( intr_hmac_done ),
-    .intr_fifo_full_o   ( intr_fifo_full ),
+    .intr_fifo_empty_o  ( intr_fifo_empty ),
     .intr_hmac_err_o    ( intr_hmac_err  ),
 
     .alert_rx_i         ( alert_if_msg_push_sha_disabled.alert_rx ),
     .alert_tx_o         ( alert_if_msg_push_sha_disabled.alert_tx )
   );
 
-  assign interrupts[HmacDone]        = intr_hmac_done;
-  assign interrupts[HmacMsgFifoFull] = intr_fifo_full;
-  assign interrupts[HmacErr]         = intr_hmac_err;
+  assign interrupts[HmacDone]         = intr_hmac_done;
+  assign interrupts[HmacMsgFifoEmpty] = intr_fifo_empty;
+  assign interrupts[HmacErr]          = intr_hmac_err;
 
   initial begin
     // drive clk and rst_n from clk_if

--- a/hw/ip/hmac/rtl/hmac_core.sv
+++ b/hw/ip/hmac/rtl/hmac_core.sv
@@ -227,6 +227,7 @@ module hmac_core import hmac_pkg::*; (
 
       StMsg: begin
         sel_rdata = SelFifo;
+        fifo_wsel = (round_q == Outer);
 
         if ( (((round_q == Inner) && reg_hash_process_flag) || (round_q == Outer))
             && (txcount >= sha_message_length)) begin
@@ -276,6 +277,7 @@ module hmac_core import hmac_pkg::*; (
 
       StOPad: begin
         sel_rdata = SelOPad;
+        fifo_wsel = 1'b1; // Remained HMAC select to indicate HMAC is in second stage
 
         if (txcnt_eq_blksz) begin
           st_d = StMsg;

--- a/hw/ip/hmac/rtl/hmac_reg_pkg.sv
+++ b/hw/ip/hmac/rtl/hmac_reg_pkg.sv
@@ -18,7 +18,7 @@ package hmac_reg_pkg;
     } hmac_done;
     struct packed {
       logic        q;
-    } fifo_full;
+    } fifo_empty;
     struct packed {
       logic        q;
     } hmac_err;
@@ -30,7 +30,7 @@ package hmac_reg_pkg;
     } hmac_done;
     struct packed {
       logic        q;
-    } fifo_full;
+    } fifo_empty;
     struct packed {
       logic        q;
     } hmac_err;
@@ -44,7 +44,7 @@ package hmac_reg_pkg;
     struct packed {
       logic        q;
       logic        qe;
-    } fifo_full;
+    } fifo_empty;
     struct packed {
       logic        q;
       logic        qe;
@@ -100,7 +100,7 @@ package hmac_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } fifo_full;
+    } fifo_empty;
     struct packed {
       logic        d;
       logic        de;

--- a/hw/ip/hmac/rtl/hmac_reg_top.sv
+++ b/hw/ip/hmac/rtl/hmac_reg_top.sv
@@ -120,25 +120,25 @@ module hmac_reg_top (
   logic intr_state_hmac_done_qs;
   logic intr_state_hmac_done_wd;
   logic intr_state_hmac_done_we;
-  logic intr_state_fifo_full_qs;
-  logic intr_state_fifo_full_wd;
-  logic intr_state_fifo_full_we;
+  logic intr_state_fifo_empty_qs;
+  logic intr_state_fifo_empty_wd;
+  logic intr_state_fifo_empty_we;
   logic intr_state_hmac_err_qs;
   logic intr_state_hmac_err_wd;
   logic intr_state_hmac_err_we;
   logic intr_enable_hmac_done_qs;
   logic intr_enable_hmac_done_wd;
   logic intr_enable_hmac_done_we;
-  logic intr_enable_fifo_full_qs;
-  logic intr_enable_fifo_full_wd;
-  logic intr_enable_fifo_full_we;
+  logic intr_enable_fifo_empty_qs;
+  logic intr_enable_fifo_empty_wd;
+  logic intr_enable_fifo_empty_we;
   logic intr_enable_hmac_err_qs;
   logic intr_enable_hmac_err_wd;
   logic intr_enable_hmac_err_we;
   logic intr_test_hmac_done_wd;
   logic intr_test_hmac_done_we;
-  logic intr_test_fifo_full_wd;
-  logic intr_test_fifo_full_we;
+  logic intr_test_fifo_empty_wd;
+  logic intr_test_fifo_empty_we;
   logic intr_test_hmac_err_wd;
   logic intr_test_hmac_err_we;
   logic cfg_hmac_en_qs;
@@ -234,29 +234,29 @@ module hmac_reg_top (
   );
 
 
-  //   F[fifo_full]: 1:1
+  //   F[fifo_empty]: 1:1
   prim_subreg #(
     .DW      (1),
     .SWACCESS("W1C"),
     .RESVAL  (1'h0)
-  ) u_intr_state_fifo_full (
+  ) u_intr_state_fifo_empty (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (intr_state_fifo_full_we),
-    .wd     (intr_state_fifo_full_wd),
+    .we     (intr_state_fifo_empty_we),
+    .wd     (intr_state_fifo_empty_wd),
 
     // from internal hardware
-    .de     (hw2reg.intr_state.fifo_full.de),
-    .d      (hw2reg.intr_state.fifo_full.d ),
+    .de     (hw2reg.intr_state.fifo_empty.de),
+    .d      (hw2reg.intr_state.fifo_empty.d ),
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.intr_state.fifo_full.q ),
+    .q      (reg2hw.intr_state.fifo_empty.q ),
 
     // to register interface (read)
-    .qs     (intr_state_fifo_full_qs)
+    .qs     (intr_state_fifo_empty_qs)
   );
 
 
@@ -314,18 +314,18 @@ module hmac_reg_top (
   );
 
 
-  //   F[fifo_full]: 1:1
+  //   F[fifo_empty]: 1:1
   prim_subreg #(
     .DW      (1),
     .SWACCESS("RW"),
     .RESVAL  (1'h0)
-  ) u_intr_enable_fifo_full (
+  ) u_intr_enable_fifo_empty (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (intr_enable_fifo_full_we),
-    .wd     (intr_enable_fifo_full_wd),
+    .we     (intr_enable_fifo_empty_we),
+    .wd     (intr_enable_fifo_empty_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -333,10 +333,10 @@ module hmac_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.intr_enable.fifo_full.q ),
+    .q      (reg2hw.intr_enable.fifo_empty.q ),
 
     // to register interface (read)
-    .qs     (intr_enable_fifo_full_qs)
+    .qs     (intr_enable_fifo_empty_qs)
   );
 
 
@@ -383,17 +383,17 @@ module hmac_reg_top (
   );
 
 
-  //   F[fifo_full]: 1:1
+  //   F[fifo_empty]: 1:1
   prim_subreg_ext #(
     .DW    (1)
-  ) u_intr_test_fifo_full (
+  ) u_intr_test_fifo_empty (
     .re     (1'b0),
-    .we     (intr_test_fifo_full_we),
-    .wd     (intr_test_fifo_full_wd),
+    .we     (intr_test_fifo_empty_we),
+    .wd     (intr_test_fifo_empty_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.fifo_full.qe),
-    .q      (reg2hw.intr_test.fifo_full.q ),
+    .qe     (reg2hw.intr_test.fifo_empty.qe),
+    .q      (reg2hw.intr_test.fifo_empty.q ),
     .qs     ()
   );
 
@@ -977,8 +977,8 @@ module hmac_reg_top (
   assign intr_state_hmac_done_we = addr_hit[0] & reg_we & ~wr_err;
   assign intr_state_hmac_done_wd = reg_wdata[0];
 
-  assign intr_state_fifo_full_we = addr_hit[0] & reg_we & ~wr_err;
-  assign intr_state_fifo_full_wd = reg_wdata[1];
+  assign intr_state_fifo_empty_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_fifo_empty_wd = reg_wdata[1];
 
   assign intr_state_hmac_err_we = addr_hit[0] & reg_we & ~wr_err;
   assign intr_state_hmac_err_wd = reg_wdata[2];
@@ -986,8 +986,8 @@ module hmac_reg_top (
   assign intr_enable_hmac_done_we = addr_hit[1] & reg_we & ~wr_err;
   assign intr_enable_hmac_done_wd = reg_wdata[0];
 
-  assign intr_enable_fifo_full_we = addr_hit[1] & reg_we & ~wr_err;
-  assign intr_enable_fifo_full_wd = reg_wdata[1];
+  assign intr_enable_fifo_empty_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_fifo_empty_wd = reg_wdata[1];
 
   assign intr_enable_hmac_err_we = addr_hit[1] & reg_we & ~wr_err;
   assign intr_enable_hmac_err_wd = reg_wdata[2];
@@ -995,8 +995,8 @@ module hmac_reg_top (
   assign intr_test_hmac_done_we = addr_hit[2] & reg_we & ~wr_err;
   assign intr_test_hmac_done_wd = reg_wdata[0];
 
-  assign intr_test_fifo_full_we = addr_hit[2] & reg_we & ~wr_err;
-  assign intr_test_fifo_full_wd = reg_wdata[1];
+  assign intr_test_fifo_empty_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_fifo_empty_wd = reg_wdata[1];
 
   assign intr_test_hmac_err_we = addr_hit[2] & reg_we & ~wr_err;
   assign intr_test_hmac_err_wd = reg_wdata[2];
@@ -1081,13 +1081,13 @@ module hmac_reg_top (
     unique case (1'b1)
       addr_hit[0]: begin
         reg_rdata_next[0] = intr_state_hmac_done_qs;
-        reg_rdata_next[1] = intr_state_fifo_full_qs;
+        reg_rdata_next[1] = intr_state_fifo_empty_qs;
         reg_rdata_next[2] = intr_state_hmac_err_qs;
       end
 
       addr_hit[1]: begin
         reg_rdata_next[0] = intr_enable_hmac_done_qs;
-        reg_rdata_next[1] = intr_enable_fifo_full_qs;
+        reg_rdata_next[1] = intr_enable_fifo_empty_qs;
         reg_rdata_next[2] = intr_enable_hmac_err_qs;
       end
 

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -394,7 +394,7 @@
           type: interrupt
         }
         {
-          name: fifo_full
+          name: fifo_empty
           width: 1
           type: interrupt
         }
@@ -1327,7 +1327,7 @@
       type: interrupt
     }
     {
-      name: hmac_fifo_full
+      name: hmac_fifo_empty
       width: 1
       type: interrupt
     }

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -207,7 +207,7 @@ module top_earlgrey #(
   logic intr_flash_ctrl_op_error;
   logic intr_rv_timer_timer_expired_0_0;
   logic intr_hmac_hmac_done;
-  logic intr_hmac_fifo_full;
+  logic intr_hmac_fifo_empty;
   logic intr_hmac_hmac_err;
   logic intr_alert_handler_classa;
   logic intr_alert_handler_classb;
@@ -608,9 +608,9 @@ module top_earlgrey #(
       .tl_o (tl_hmac_d_d2h),
 
       // Interrupt
-      .intr_hmac_done_o (intr_hmac_hmac_done),
-      .intr_fifo_full_o (intr_hmac_fifo_full),
-      .intr_hmac_err_o  (intr_hmac_hmac_err),
+      .intr_hmac_done_o  (intr_hmac_hmac_done),
+      .intr_fifo_empty_o (intr_hmac_fifo_empty),
+      .intr_hmac_err_o   (intr_hmac_hmac_err),
       
       // [0]: msg_push_sha_disabled 
       .alert_tx_o  ( alert_tx[0:0] ),
@@ -767,7 +767,7 @@ module top_earlgrey #(
       intr_alert_handler_classb,
       intr_alert_handler_classa,
       intr_hmac_hmac_err,
-      intr_hmac_fifo_full,
+      intr_hmac_fifo_empty,
       intr_hmac_hmac_done,
       intr_flash_ctrl_op_error,
       intr_flash_ctrl_op_done,


### PR DESCRIPTION
Fix merged conflict for PR https://github.com/lowRISC/opentitan/pull/1800

I am not sure what is the best way to do this, when I did "rebase", there are two conflicts to merge:
1). `hmac_base_vseq.sv`: I kept the `hmac_txempty` version of the code and delete the conflicts from HEAD.
2). `hmac_sanity_vseq.sv`: In `hmac_txempty` version of the [code](https://github.com/lowRISC/opentitan/pull/1800/files), I change line 111-117 to the following:
```
        if (do_hash_start) begin
          // wait for interrupt to assert, check status and clear it
          if (intr_hmac_done_en) begin
            wait(cfg.intr_vif.pins[HmacDone] === 1'b1);
          end else begin
            csr_spinwait(.ptr(ral.intr_state.hmac_done), .exp_data(1'b1));
          end
        end
``` 

Sorry for the inconvenience, and hope that helps.